### PR TITLE
Add dry run mode and actual checks counter.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,10 @@ pub struct CLI {
     /// when to use color in the terminal output, either "always" or "never"
     #[argh(option, default = "ColorChoice::Always")]
     pub color: ColorChoice,
+
+    /// when set, only print the feature combos that will be checked instead of actually checking them
+    #[argh(switch)]
+    pub dry_run: bool,
 }
 
 impl CLI {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,7 +34,7 @@ pub struct CLI {
     #[argh(option, default = "ColorChoice::Always")]
     pub color: ColorChoice,
 
-    /// when set, only print the feature combos that will be checked instead of actually checking them
+    /// print feature combos without running checks for them
     #[argh(switch)]
     pub dry_run: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ fn main() -> anyhow::Result<()> {
                 });
             }
         }
-        println!("{bold}Actual checks: {info}{}{reset}", actual_checks);
+        println!("{bold}Actual checks: {info}{actual_checks}{reset}");
     }
 
     if !failures.is_empty() {
@@ -108,7 +108,11 @@ fn main() -> anyhow::Result<()> {
         bail!("Some packages failed to be checked.");
     }
 
-    println!("{success}{bold}Feature combination checks successful! Congrats :){reset}");
+    if cli.dry_run {
+        println!("Dry run completed, no checks were run.")
+    } else {
+        println!("{success}{bold}Feature combination checks successful! Congrats :){reset}");
+    }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,9 @@ fn main() -> anyhow::Result<()> {
         );
         println!("{bold}Estimated checks: {info}{}{reset}", estimated_checks);
 
+        let mut actual_checks = 0;
         for combo in feature_combos(&storage, package_config) {
+            actual_checks += 1;
             let mut features = Vec::with_capacity(combo.len());
 
             for &key in combo.iter() {
@@ -80,6 +82,9 @@ fn main() -> anyhow::Result<()> {
 
             println!("\t{dim}Checking:{reset} {info}{:?}{reset}", features);
 
+            if cli.dry_run {
+                continue;
+            }
             let status = check_with_features(&name, &cli.manifest_path, &combo, &storage)
                 .with_context(|| format!("Tried checking package {name}."))?;
 
@@ -90,6 +95,7 @@ fn main() -> anyhow::Result<()> {
                 });
             }
         }
+        println!("{bold}Actual checks: {info}{}{reset}", actual_checks);
     }
 
     if !failures.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn main() -> anyhow::Result<()> {
             "{bold}Package {info}{name}{reset}{bold} with {info}{}{reset}{bold} features.{reset}",
             storage.len()
         );
-        println!("{bold}Estimated checks: {info}{}{reset}", estimated_checks);
+        println!("{bold}Estimated checks: {info}{estimated_checks}{reset}");
 
         let mut actual_checks = 0;
         for combo in feature_combos(&storage, package_config) {
@@ -109,7 +109,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     if cli.dry_run {
-        println!("Dry run completed, no checks were run.")
+        println!("{info}{bold}Dry run completed, no checks were run.{reset}");
     } else {
         println!("{success}{bold}Feature combination checks successful! Congrats :){reset}");
     }


### PR DESCRIPTION
Adds a CLI flag to allow the user to only print the checks without executing them, and a counter that prints out exactly how many combos were encountered.